### PR TITLE
Simulator fixes

### DIFF
--- a/game/__init__.py
+++ b/game/__init__.py
@@ -29,8 +29,9 @@ def run_game(seed: int, config: GameConfig, player_types):
     # Init board
     board = Board(size=config.board_size, n_cards=config.n_cards)
 
-    start_discards = [int(np.ceil(config.start_discard_size // config.n_players))] * (config.n_players - 1)
-    start_discards.append(config.start_discard_size - sum(start_discards))
+    start_discards = [config.start_discard_size // config.n_players] * config.n_players
+    for i in range(config.start_discard_size - sum(start_discards)):
+        start_discards[i] += 1
 
     start, start_player_id = False, -1
     win, lose = False, False

--- a/game/board.py
+++ b/game/board.py
@@ -20,7 +20,9 @@ class Board:
         self.min_board = forward_fill_na(self.board)
 
     def check_if_position_legal(self, new_card, position, hand_size):
-        if new_card == 0:
+        if hand_size == 0:
+            return False
+        elif new_card == 0:
             return not self.start
         elif new_card == self.n_cards+1:
             return (not self.finish) and (sum(np.isnan(self.board))==0)

--- a/game/config.py
+++ b/game/config.py
@@ -9,11 +9,12 @@ class GameConfig:
     n_cards: int = 80
     n_finish: int = 5
     start_discard_size: int = 2
-    pass_discard_size: int = 2
+    pass_discard_size: int = 8
     
     def __post_init__(self):
         assert self.n_players > 0
         assert self.board_size > 0 and self.board_size < self.n_cards
         assert self.n_finish > 0
         assert self.n_cards >= min(1, np.ceil(self.n_players * self.hand_sizes) - self.n_finish)
-        assert self.hand_sizes >= max([self.pass_discard_size, self.start_discard_size, np.ceil(self.start_discard_size / self.n_players)])
+        assert self.hand_sizes >= max([self.pass_discard_size, np.ceil(self.start_discard_size / self.n_players)])
+        assert self.start_discard_size < self.hand_sizes * self.n_players

--- a/game/config.py
+++ b/game/config.py
@@ -8,8 +8,8 @@ class GameConfig:
     hand_sizes: int = 5
     n_cards: int = 80
     n_finish: int = 5
-    start_discard_size: int = 2
-    pass_discard_size: int = 8
+    start_discard_size: int = 8
+    pass_discard_size: int = 2
     
     def __post_init__(self):
         assert self.n_players > 0

--- a/game/player.py
+++ b/game/player.py
@@ -23,7 +23,7 @@ class Player(ABC):
         '''
         returns true if it's possible to use the standard discard to pass the turn
         '''
-        return len(self.hand) > self.pass_discard_size
+        return len(self.hand) >= self.pass_discard_size
     
     def check_possible_play(self):
         '''

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import inspect
 from os.path import dirname, join
 from os import cpu_count
 import numpy as np
+import warnings
 
 parser = argparse.ArgumentParser(
     prog='main.py',
@@ -120,7 +121,9 @@ best_game_results = { "outcome": None, "results": None, "metrics": None }
 
 
 def _process_game(game_id):
-    results = run_game(seed=args.start_seed + game_id, config=config, player_types=player_types)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        results = run_game(seed=args.start_seed + game_id, config=config, player_types=player_types)
     metrics = compute_metrics(game_config=config, player_remapping_dict=player_remapping_dict, percentage_digits=args.percentage_digits, **results)
     return game_id, results, metrics
 

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ config_group.add_argument("--board-size", type=int, default=36, help="The size o
 config_group.add_argument("--hand-sizes", type=int, default=5, help="The size of each players' hand")
 config_group.add_argument("--n-cards", type=int, default=80, help="The total number of numbered cards")
 config_group.add_argument("--n-finish", type=int, default=5, help="The total number of finish cards")
-config_group.add_argument("--start-discard-size", type=int, default=2, help="The number of cards to discard when the start card is played")
+config_group.add_argument("--start-discard-size", type=int, default=8, help="The number of cards to discard when the start card is played")
 config_group.add_argument("--pass-discard-size", type=int, default=2, help="The number of cards to discard when passing the turn")
 # Run config
 parser.add_argument("--games", type=int, default=10, help="The number of games to simulate")


### PR DESCRIPTION
* Fix computation of cards to discard when the start is played. Now the default is correctly 8 (was 2) and the algorithm distributes in a more fair way (e.g., for 8 cards and 3 players, it computes `[3, 3, 2]` when previously was `[2, 2, 4]`).
* Fix `board.check_if_position_legal` in the case in which the `hand_size` is `0`
* Fix inequality for checking when it's possible to discard (from `>` to `>=`)
* Wrap `run_game` calls with ignore warnings to silence warnings within player agent implementations